### PR TITLE
I just learned the hard way.

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ If the add-on runs into trouble and can't back up, you should see a big red box 
 ### Will this fill up my Google Drive?  Why are my snapshots so big?
 You'll need tot take care to ensure you don't configure this to blow up your Google Drive.  You might want to consider:
 *   If your snapshots are HUGE, its probably because Home Assistant by defaults keeps 10 days of sensor history.  Consider setting `purge_keep_days: N` in your [recorder confiuration](https://www.home-assistant.io/components/recorder/) to trim it down to something more manageable, like 1 day of history.
+*   Also consider that some of the add-ons are designed to manage large amounts of media.  For example, add-ons like the Plex Media Server are designed to store media in the /share folder, and Mobile Upload folders default to a sub-folder in the addons folder.  If you migrate all of your media to the HASS.io folder structure and you don't exclude it from the backup, you _could easily chew up your entire Google Drive space in a single snapshot_.
 *   If you use the Google Drive Desktop sync client, you'll porbably want to tell it not to sync this folder (its available in the options).
 
 ### I want my snapshots to sync to my Desktop computer too


### PR DESCRIPTION
Plex media server is the only add-on that's caused a bloated backup.  My data is stored in MySQL, but my media...had I know, would have been managed by Plex Media Server _outside of HASS.io_.