### PR TITLE
Readme : binary_sensor.snapshots_stale state

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The add-on creates a few sensors that show the status of snapshots that you coul
     type: conditional
     conditions:
       - entity: binary_sensor.snapshots_stale
-        state_not: 'False'
+        state_not: 'off'
     card:
       type: markdown
       content: >-


### PR DESCRIPTION
Since the version 0.101.1, the binary_sensor snapshots_stale state doesn't use true/false state but on/off.

see :
https://github.com/sabeechen/hassio-google-drive-backup/issues/222
https://github.com/sabeechen/hassio-google-drive-backup/commit/446e8919806dda3f2197bde14b1f8b02ab7e2ff9