### PR TITLE
Unify add-on documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,179 +1,115 @@
 # Home Assistant Google Drive Backup
+
 ![screenshot](images/screenshot.png)
+
 ## About
-A complete and easy to configure solution for backing up your snapshots to Google Drive
-* Automatically creates new snapshots on a configurable schedule.
-* Automatically uploads snapshot to Drive, even the ones it didn't create.
-* Automatically cleans up old snapshots in Home Assistant and Google drive so you don't run out of space.
-* Lets you upload snapshots directly from Google Drive, which makes [restoring from a fresh install](#how-do-i-restore-a-snapshot) very easy.
-* Integrates with Home Assistant Notifications, and provides sensors you can trigger off of.
-* Simple UI focused on clarity, usability and getting out of the way.  
 
-This is for you if you want to quickly set up a backup strategy without much fuss.  It doesn't require much familiarity with Home Assistant, its architectire, or Google Drive.  Detailed install instrctions are provided below but you can just add the repo, click install and open the Web UI.  It will tell you what to do and only takes a few simple clicks.
+A complete and easy way to back up your Home Assistant snapshots to Google Drive.
 
-Do you like this?  Give me a reason to keep doing it and [![Repo Screenshot](images/bmc.png)](https://www.buymeacoffee.com/sabeechen)
+This is for you if you want to quickly set up a backup strategy without much fuss. It doesn't require much familiarity with Home Assistant, its architecture, or Google Drive. Detailed install instructions are provided below but you can just add the repo, click install and open the Web UI. It will tell you what to do and only takes a few simple clicks.
+
+### Features
+
+- Creates snapshots on a configurable schedule.
+- Uploads snapshot to Drive, even the ones it didn't create.
+- Clean up old snapshots in Home Assistant and Google Drive, so you don't run out of space.
+- Restore from a fresh install or recover quickly from disaster by uploading your snapshots directly from Google Drive.
+- Integrates with Home Assistant Notifications, and provides sensors you can trigger off of.
+- Notifies you when something goes wrong with your snapshots.
+- Super easy installation and configuration.
+- Privacy-centric design philosophy.
+- Comprehensive documentation.
+- _Most certainly_ doesn't mine bitcoin on your home automation server. Definitely no.
+
+---
+
+Do you like this? Give me a reason to keep doing it and
+
+[![Repo Screenshot](images/bmc.png)](https://www.buymeacoffee.com/sabeechen)
 
 ## Installation
-The add-on is installed like any other.
-1.   Go to your Home Assistant web UI, "Supervisor" > "Add-on Store", Click 3-dots menu at upper right > "Repositories" and add this repository URL: [https://github.com/sabeechen/hassio-google-drive-backup](https://github.com/sabeechen/hassio-google-drive-backup)
-  
-     ![Add Repo Screenshot](images/add_ss.png)
-2.   Scroll down the page to find the new repository, and click the new add-on named "Home Assistant Google Drive Backup"
 
-     ![Repo Screenshot](images/repo_ss.png)
-3.   Click "Install" and give it a few minutes to finish downloading.
-4.   Click "Start", give it a few seconds to spin up, and then click the "Open Web UI" button that appears.  For the majority of people this should take you to [https://hhomeassistant.local:1627/](https://homeassistant.local:1627/).
-5.   The "Getting Started" page will tell you how many snapshots you have and what it will do with them once you connect it to Google Drive.  You can click "Settings" to change those options throught he add-on (takes effect immediately), or update them from the page where you installed the add-on as shown below (restart for them to take effect).
-6.   Click the "Authenticate with Drive" button to link the add-on with your Google Drive account.  Alternatively, you can generate your [own Google API credentials](#can-i-use-my-own-google-api-information-to-authenticate-instead-of-yours), though the process is not simple.
-7.   You should be redirected automatically to the backup status page.  Here you can make a new snapshot, see the progress of uploading to Google Drive, etc.  You're done!
+The add-on is installed like any other.
+
+1. Navigate in your Home Assistant frontend to **Supervisor** -> **Add-on Store**.
+
+2. Click 3-dots menu at upper right > **Repositories** and add this repository URL: [https://github.com/sabeechen/hassio-google-drive-backup](https://github.com/sabeechen/hassio-google-drive-backup)
+
+   ![Add Repo Screenshot](images/add_ss.png)
+
+3. Scroll down the page to find the new repository, and click the new add-on named "Home Assistant Google Drive Backup"
+
+   ![Repo Screenshot](images/repo_ss.png)
+
+4. Click <kbd>Install</kbd> and give it a few minutes to finish downloading.
+
+5. Click <kbd>Start</kbd>, give it a few seconds to spin up, and then click the `Open Web UI` button that appears. For the majority of people, this should take you to [https://homeassistant.local:1627/](https://homeassistant.local:1627/).
+
+6. The "Getting Started" page will tell you how many snapshots you have and what it will do with them once you connect it to Google Drive. You can click `Settings` to change those options through the add-on (takes effect immediately), or update them from the page where you installed the add-on as shown below (restart for them to take effect).
+
+7. Click the `Authenticate with Drive` button to link the add-on with your Google Drive account. Alternatively, you can generate your [own Google API credentials](#can-i-use-my-own-google-api-information-to-authenticate-instead-of-yours), though the process is not simple.
+
+8. You should be redirected automatically to the backup status page. Here you can make a new snapshot, see the progress of uploading to Google Drive, etc. You're done!
 
 ## Configuration Options
-Settings can be change easily by starting the add-on and clicking "Settings" in the web UI.  The UI explains what each setting is and you don't need to modify anything before clicking "start".  If you  would still prefer to modify the settings in json, the options are detailed below.
-*  **max_snapshots_in_hassio** (default: 4): The number of snapshots the add-on will allow Home Assistant to store locally before old ones are deleted.
-    > #### Example: Keep 10 snapshots in Home Assistant
-    > ```json
-    > "max_snapshots_in_hassio": "10"
-    > ```
 
-*  **max_snapshots_in_google_drive** (default: 4): The number of snapshots the add-on will keep in Google Drive before old ones are deleted.  Google Drive gives you 15GB of free storage (at the time of writing) so plan accordingly if you know how big your snapshots are.
-    > #### Example: Keep 10 snapshots in Google Drive
-    > ```json
-    > "max_snapshots_in_google_drive": "10"
-    > ```
+The list of configurable options is available [here](./hassio-google-drive-backup/DOCS.md#configuration).
 
-*  **days_between_snapshots** (default: 3): THow often a new snapshot should be scheduled, eg "1" for daily and "7" for weekly.
-    > #### Example: Take a snapshot every 3 days.
-    > ```json
-    > "days_between_snapshots": "3"
-    > ```
-
-*  **snapshot_time_of_day** (default: None): The time of day (local time) that new snapshots should be created in 24 hour "HH:MM" format.  When not specified (the default), snapshots are created at the same time of day of the most recent snapshot.
-    > #### Example: Create snapshots at 1:30pm
-    > ```json
-    > "snapshot_time_of_day": "13:30"
-    > ```
-
-*  **specify_snapshot_folder** (default: False): When true, you must select the folder in Google Drive where snapshots are stored.  Once you turn this on, restart the add-on and visit the web-ui to be prompted to select the snapshot folder.
-    > #### Example: Specify the snapshot folder.
-    > ```json
-    > "specify_snapshot_folder": true
-    > ```
-
-*  **background_color** and **accent_color**: The background and accent colors for the web UI.  You can use this to make the UI fit in with whatever color scheme you use in Home Assistant.  When unset, the interface matches Home Assistant's default blue/white style.
-    > #### Example: Use a dark and red theme
-    > ```json
-    > "background_color": "#242424"
-    > "accent_color": "#7D0034"
-    > ```
-
-*   **snapshot_stale_minutes** (default: 180):  How long to wait after a snapshot should have been created to consider snapshots stale and in need of attention.  Setting this too low can cause you to be notified of transient errors, ie the internet, Google Drive, or Home Assistant being offline briefly.
-    > #### Example: Notify after 12 hours of staleness
-    > ```json
-    > "snapshot_stale_minutes": "500"
-    > ```
-*   **snapshot_password** (default: None):  When set, snapshots are created witha password.  You can use a value from your secrets.yaml by prefixing the password with "!secret". You'll need to remember this password when restoring snapshots.
-    > #### Example: Use a password for snapshot archives
-    > ```json
-    > "snapshot_password": "super_secret"
-    > ```
-    > #### Example: Use a password from secrets.yaml
-    > ```json
-    > "snapshot_password": "!secret snapshot_password"
-    > ```
-*   **snapshot_name** (default: "{type} Snapshot {year}-{month}-{day} {hr24}:{min}:{sec}"):  Sets the name for new snapshots.  Variable parameters of the form "{variable_name}" can be used to modify the name to your liking.  A list of available variables are given [here](#can-i-give-snapshots-a-different-name).
-    > #### Example: Create snapshot names like 'Full Snapshot HA 0.92.0'
-    > ```json
-    > "snapshot_name": "{type} Snapshot {version_ha}"
-    > ```
-*   **send_error_reports** (default: False):  When true, the text of unexpected errors will be sent to database maintained by the developer.  This helps idenfity problems with new releases and provide better context messages when errors come up.
-    > #### Example: Allow sending error reports
-    > ```json
-    > "send_error_reports": true
-    > ```
-*   **UI Server Options** The UI is exposed through a webserver on port 1627, which you can map to an externally visible port from the add-on "Network" panel, which also defaults to port 1627.  You can configure a few more options to add SSL or require your Home assistant username/password.  In a future release, the add-on will support [ingress](https://www.home-assistant.io/blog/2019/04/15/hassio-ingress/) but for now it is disabled for compatibility reasons (see [this issue](https://github.com/sabeechen/hassio-google-drive-backup/issues/19)).
-    *   **require_login** (default: false): When true, requires your home assistant username and password to access the Web UI.
-        > #### Example: Don't require login
-        > ```json
-        > "require_login": false
-        > ```
-    * **use_ssl** (default: false): determines if the add-on's webpage should only expose its interface over ssl.  If you use the [Duck DNS Add-on](https://www.home-assistant.io/addons/duckdns/) with the default settings then `"use_ssl": true` setting this to true should just work, if not [see below](#configuration-options).
-    *   **certfile** (default: /ssl/certfile.pem): The path to your ssl keyfile
-    *   **keyfile** (default: /ssl/keyfile.pem): the path to your ssl certfile
-        > #### Example: Use certs you keep in a weird place
-        > ```json
-        >   "certfile": "/ssl/weird/path/cert.pem",
-        >   "keyfile": "/ssl/weird/path/key.pem"
-        > ```
-*   **verbose** (default: false): If true, enable additional debug logging.  Useful if you start seeing errors and need to file a bug with me.
-    > #### Example: Turn on verbose logging
-    > ```json
-    > `"verbose": true`
-    > ```
-*   **generational_*** (default: None): When set, older snapshots will be kept longer using a [generational backup scheme](https://en.wikipedia.org/wiki/Backup_rotation_scheme). See the [question below](#can-i-keep-older-backups-for-longer) for configuration options.
-    > #### Example: Keep a snapshot once every day 3 days and once a week for 4 weeks
-    > ```json
-    >   "generational_days": 3,
-    >   "generational_weeks": 4
-    > ```
-*   **exclude_folders** (default: None): When set, excludes the comma separated list of folders by creating a partial snapshot.
-*   **exclude_addons** (default: None): When set, excludes the comma separated list of addons by creating a partial snapshot.
-    > #### Example: Create partial snapshots with no folders and no configurator add-on
-    > ```json
-    >   "exclude_folders": "homeassistant,ssl,share,addons/local",
-    >   "exclude_addons": "core_configurator"
-    > ```
-        Note: folders and add-ons must be identified by their 'slug' name.  Its recommended to use the "Settings" dialog within the add-on web UI to configure partial snapshots since these names are esoteric and hard to find.
-*   **enable_snapshot_stale_sensor** (default: true): When false, the add-on will not publish the [binary_sensor.snapshots](#how-will-i-know-this-will-be-there-when-i-need-it) stale sensor.
-*   **enable_snapshot_state_sensor** (default: true): When false, the add-on will not publish the [sensor.snapshot_state](#how-will-i-know-this-will-be-there-when-i-need-it)  sensor.
-*   **notify_for_stale_snapshots** (default: true): When false, the add-on will send a [persistent notification](#how-will-i-know-this-will-be-there-when-i-need-it) in Home Assistant when snapshots are stale.
-    > #### Example: Turn off notifications and staleness sensor
-    > ```json
-    >   "enable_snapshot_stale_sensor": false,
-    >   "enable_snapshot_state_sensor": false,
-    >   "notify_for_stale_snapshots": false
-    > ```
+_Note_: The configuration can be changed easily by starting the add-on and clicking `Settings` in the web UI.
+The UI explains what each setting is and you don't need to modify anything before clicking `Start`.
 
 ## FAQ
+
 ### How will I know this will be there when I need it?
-Home Assistant is notorious for failing silently, and your backups aren't something you want to find is broken after an erroneous comma makes you unable to turn on any of the lights in your house.  Thats why I've added some functionality to keep you informed if things start to break.  If the add-on runs into trouble and gets more than 12 hours behind its schedule, you'll know in two ways:
-* Notifications in Home Assistant UI
+
+Home Assistant is notorious for failing silently, and your backups aren't something you want to find is broken after an erroneous comma makes you unable to turn on any of the lights in your house. Thats why I've added some functionality to keep you informed if things start to break. If the add-on runs into trouble and gets more than 12 hours behind its schedule, you'll know in two ways:
+
+- Notifications in Home Assistant UI
 
   ![Notification](images/notification_error.png)
 
-* A [binary_sensor](#lovelace-card) you can use to trigger additional actions.
-  
-   ![Binary Sensor](images/binary_sensor.png)
+- A [binary_sensor](#lovelace-card) you can use to trigger additional actions.
 
-Redundancy is the foundation of reliability.  With local snapshots, Google Drive's backups, and two flavors of notification I think you're covered.
+  ![Binary Sensor](images/binary_sensor.png)
+
+Redundancy is the foundation of reliability. With local snapshots, Google Drive's backups, and two flavors of notification I think you're covered.
 
 ### How do I restore a snapshot?
-If you can still get to the addon's web-UI then can select "Actions" -> "Upload" from any snapshot to have it copied back into Home Assistant. If not, you'll need to start up a fresh installation of Hass.io and do the following:
-- On your fresh install of Hass.io:
-  *  [Install the add-on.](#installation)  Once linked with Google Drive, you should see the snapshots you created previously show up.  You should see a warning pop up about finding an "Existing snapshot folder" which is expected, you can just ignore it for now.
-  * Click "Actions" -> "Upload" on the snapshot you want to use which will upload the snapshot to Home Assistant directly from Google Drive.  Wait for the upload to finish.
-  * Click "Actions" -> "Restore" to be taken to the Hass.io restore page, or just navigate there through the Home Assistant interface ("Hass.io" -> "Snapshots").
-  * You'll see the snapshot you uploaded.  Click on it and select "Wipe & Restore".  Wait a while for it to complete (maybe a long while).  Congrats! you're back up and running.
 
-Note: You can also just copy a snapshots manually from Google Drive to your /backup folder using something like the Sambda addon.  I've found the steps above to be a little easier, since it works for any operating system, network setup, etc.
+If you can still get to the addon's web-UI then can select "Actions" -> "Upload" from any snapshot to have it copied back into Home Assistant. If not, you'll need to start up a fresh installation of Home Assistant and do the following:
 
-### I never look at HA notifications.  Can I show information about backups in my Home Assistant Interface?
-The add-on creates a few sensors that show the status of snapshots that you could trigger automations off of.  `binary_sensor.snapshots_stale` becomes true when the add-on has trouble backing up or creating snapshots.  For example the lovelace card below only shows up in the UI when snapshots go stale:
+- On your fresh install of Home Assistant:
+  - [Install the add-on.](#installation) Once linked with Google Drive, you should see the snapshots you created previously show up. You should see a warning pop up about finding an "Existing snapshot folder" which is expected, you can just ignore it for now.
+  - Click "Actions" -> "Upload" on the snapshot you want to use which will upload the snapshot to Home Assistant directly from Google Drive. Wait for the upload to finish.
+  - Click "Actions" -> "Restore" to be taken to the Home Assistant restore page, or just navigate there through the Home Assistant interface ("Home Assistant" -> "Snapshots").
+  - You'll see the snapshot you uploaded. Click on it and select "Wipe & Restore". Wait a while for it to complete (maybe a long while). Congrats! you're back up and running.
+
+Note: You can also just copy a snapshots manually from Google Drive to your /backup folder using something like the Sambda addon. I've found the steps above to be a little easier, since it works for any operating system, network setup, etc.
+
+### I never look at HA notifications. Can I show information about backups in my Home Assistant Interface?
+
+The add-on creates a few sensors that show the status of snapshots that you could trigger automations off of. `binary_sensor.snapshots_stale` becomes true when the add-on has trouble backing up or creating snapshots. For example the lovelace card below only shows up in the UI when snapshots go stale:
+
 #### Lovelace Card
 
-    type: conditional
-    conditions:
-      - entity: binary_sensor.snapshots_stale
-        state_not: 'off'
-    card:
-      type: markdown
-      content: >-
-        Snapshots are stale! Please visit the "Home Assistant Google Drive Backup" add-on
-        status page for details.
-      title: Stale Snapshots!`
+```yaml
+type: conditional
+conditions:
+  - entity: binary_sensor.snapshots_stale
+    state_not: "off"
+card:
+  type: markdown
+  content: >-
+    Snapshots are stale! Please visit the "Home Assistant Google Drive Backup" add-on
+    status page for details.
+  title: Stale Snapshots!`
+```
+
 #### Mobile Notifications
+
 If you have [android](https://github.com/Crewski/HANotify) or [iOS](https://www.home-assistant.io/docs/ecosystem/ios/), [other notifications](https://www.home-assistant.io/components/notify/) set up, this automation would let you know if things go stale:
 
-
+```yaml
     - alias: Snapshots went stale
       id: 'snapshots_went_stale'
       trigger:
@@ -188,107 +124,128 @@ If you have [android](https://github.com/Crewski/HANotify) or [iOS](https://www.
           title: Snapshots are Stale
           message: Please visit the 'Home Assistant Google Drive Backup ' add-on status page
             for details.
+```
 
-You could automate anything off of this binary sensor.  The add-on also exposes a sensor `sensor.snapshot_backup` that exposes the details of each snapshot.  I'm working on a custom lovelace component to expose that information.
+You could automate anything off of this binary sensor. The add-on also exposes a sensor `sensor.snapshot_backup` that exposes the details of each snapshot. I'm working on a custom lovelace component to expose that information.
 
 ### Can I specify what time of day snapshots should be created?
-You can add `"snapshot_time_of_day": "13:00"` to your add-on configuration to make snapshots always happen at 1pm.  Specify the time in 24 hour format of `"HH:MM"`.  When unspecified, the next snapshot will be created at the same time of day as the last one.
+
+You can add `"snapshot_time_of_day": "13:00"` to your add-on configuration to make snapshots always happen at 1pm. Specify the time in 24 hour format of `"HH:MM"`. When unspecified, the next snapshot will be created at the same time of day as the last one.
 
 ### Can I keep older backups for longer?
->This is just an overview of how to keep older snapshots longer.  [See here](https://github.com/sabeechen/hassio-google-drive-backup/blob/master/hassio-google-drive-backup/GENERATIONAL_BACKUP.md) for a more in-depth explanation.
 
-The add-on can be configured to keep [generational backups](https://en.wikipedia.org/wiki/Backup_rotation_scheme) on daily, weekly, monthly, and yearly intervals instead of just deleting the oldest snapshot.  This can be useful if, for example, you've made an erroneous change but haven't noticed for several days and all the backups before the change are gone.  With a configuration setting like this...
-```json
-  "generational_days": 3,
-  "generational_weeks": 4,
-  "generational_months": 12,
-  "generational_years": 5
- ```
- ... a snapshot will be kept for the last 3 days, the last 4 weeks, the last 12 months, and the last 5 years.  Additionally you may configure the day of the week, day of the month, and day of the year that weekly, monthly, and yearly snapshots are maintained.
-  ```json
-    "generational_days": 3,
-    
-    "generational_weeks": 4,
-    "generational_day_of_week": "mon",  // Can be 'mon', 'tue', 'wed', 'thu', 'fri', 'sat' or 'sun' (defaults to 'mon')
+> This is just an overview of how to keep older snapshots longer. [See here](https://github.com/sabeechen/hassio-google-drive-backup/blob/master/hassio-google-drive-backup/GENERATIONAL_BACKUP.md) for a more in-depth explanation.
 
-    "generational_months": 12,
-    "generational_day_of_month": 1, // Can be 1 through 31 (defaults to 1) 
+The add-on can be configured to keep [generational backups](https://en.wikipedia.org/wiki/Backup_rotation_scheme) on daily, weekly, monthly, and yearly intervals instead of just deleting the oldest snapshot. This can be useful if, for example, you've made an erroneous change but haven't noticed for several days and all the backups before the change are gone. With a configuration setting like this...
 
-    "generational_years": 5,
-    "generational_day_of_year": 1, // can be 1 through 365 (defaults to 1)
- ```
- * Any combination of days, weeks, months, and years can be used.  They all default to 0.
- * Its highly reccommended to set '`"days_between_snapshots": 1`' to ensure a snapshot is available for each day.
- * Ensure you've set `max_snapshots_in_drive` appropriatly high to keep enough snapshots (24 in the example above).
- * Once this option is enabled, it may take several days or weeks to see older snapshots get cleaned up.  Old snapshots will only get deleted when the number present exceeds `max_snapshots_in_drive` or `max_snapshots_in_hassio`
- 
-### I already have something that creates snapshots on a schedule.  Can I use this just to backup to Google Drive?
-If you set '`"days_between_snapshots": 0`', then the add-on won't try to create new snapshots but will still back up any it finds to Google Drive and clean up old snapshots in both Home Assistant and Google Drive.  This can be useful if you already  have for example an automation that creates snapshots on a schedule.
+```yaml
+generational_days: 3
+generational_weeks: 4
+generational_months: 12
+generational_years: 5
+```
+
+... a snapshot will be kept for the last 3 days, the last 4 weeks, the last 12 months, and the last 5 years. Additionally you may configure the day of the week, day of the month, and day of the year that weekly, monthly, and yearly snapshots are maintained.
+
+```yaml
+generational_days: 3
+
+generational_weeks: 4
+generational_day_of_week: "mon" # Can be 'mon', 'tue', 'wed', 'thu', 'fri', 'sat' or 'sun' (defaults to 'mon')
+
+generational_months: 12
+generational_day_of_month: 1 # Can be 1 through 31 (defaults to 1)
+
+generational_years: 5
+generational_day_of_year: 1 # can be 1 through 365 (defaults to 1)
+```
+
+- Any combination of days, weeks, months, and years can be used. They all default to 0.
+- Its highly reccommended to set '`days_between_snapshots: 1`' to ensure a snapshot is available for each day.
+- Ensure you've set `max_snapshots_in_drive` appropriatly high to keep enough snapshots (24 in the example above).
+- Once this option is enabled, it may take several days or weeks to see older snapshots get cleaned up. Old snapshots will only get deleted when the number present exceeds `max_snapshots_in_drive` or `max_snapshots_in_hassio`
+
+### I already have something that creates snapshots on a schedule. Can I use this just to backup to Google Drive?
+
+If you set '`days_between_snapshots: 0`', then the add-on won't try to create new snapshots but will still back up any it finds to Google Drive and clean up old snapshots in both Home Assistant and Google Drive. This can be useful if you already have for example an automation that creates snapshots on a schedule.
 
 ### Can I give snapshots a different name?
-The config option `snapshot_name` can be changed to give snapshots a different name or with a date format of your choosing.  The default is `{type} Snapshot {year}-{month}-{day} {hr24}:{min}:{sec}`, which makes snapshots with a name like `Full Snapshot 2019-10-31 14:00:00`.  Using the settings menu in the Web UI, you can see a preview of what a snapshot name will look like but you can also set it in the add-on's options.  Below is the list of variables you can add to modify the name to your liking.
-* `{type}`: The type of snapshot, either 'Full' or 'Partial'
-* `{year}`: Year in 4 digit format (eg 2019)
-* `{year_short}`: Year in 2 digit format (eg 19)
-* `{weekday}`: Long day of the week (eg Monday, ..., Sunday)
-* `{weekday_short}`: Short day of week (eg Mon, ... Sun)
-* `{month}`: 2 digit month (eg 01, ... 12)
-* `{month_long}`: Month long name (January, ... , December)
-* `{month_short}`: Month long name (Jan, ... , Dec)
-* `{ms}`: Milliseconds (001, ..., 999)
-* `{day}`: Day of the month (01, ..., 31)
-* `{hr24}`: 2 digit hour of the day (0, ..., 24)
-* `{hr12}`: 2 digit hour of the day (0, ..., 12)
-* `{min}`: 2 digit minute of the hour (0, ..., 59)
-* `{sec}`: 2 digit second of the minute (0, ..., 59)
-* `{ampm}`: am or pm, depending on the time of day
-* `{version_ha}`, Home Assistant version string (eg 0.91.3)
-* `{version_hassos}`: HassOS version string (eg 0.2.15)
-* `{version_super}`: , Supervisor version string (eg 1.2.19)
-* `{date}`: Locale aware date (eg 2019/01/01).
-* `{time}`: Locale aware time (eg 02:03:04 am)
-* `{datetime}`: Locale-aware datetime string
-* `{isotime}`: Date and time in ISO format 
-* `{hostname}`: The Home Assistant machine's hostname 
 
+The config option `snapshot_name` can be changed to give snapshots a different name or with a date format of your choosing. The default is `{type} Snapshot {year}-{month}-{day} {hr24}:{min}:{sec}`, which makes snapshots with a name like `Full Snapshot 2019-10-31 14:00:00`. Using the settings menu in the Web UI, you can see a preview of what a snapshot name will look like but you can also set it in the add-on's options. Below is the list of variables you can add to modify the name to your liking.
+
+- `{type}`: The type of snapshot, either 'Full' or 'Partial'
+- `{year}`: Year in 4 digit format (eg 2019)
+- `{year_short}`: Year in 2 digit format (eg 19)
+- `{weekday}`: Long day of the week (eg Monday, ..., Sunday)
+- `{weekday_short}`: Short day of week (eg Mon, ... Sun)
+- `{month}`: 2 digit month (eg 01, ... 12)
+- `{month_long}`: Month long name (January, ... , December)
+- `{month_short}`: Month long name (Jan, ... , Dec)
+- `{ms}`: Milliseconds (001, ..., 999)
+- `{day}`: Day of the month (01, ..., 31)
+- `{hr24}`: 2 digit hour of the day (0, ..., 24)
+- `{hr12}`: 2 digit hour of the day (0, ..., 12)
+- `{min}`: 2 digit minute of the hour (0, ..., 59)
+- `{sec}`: 2 digit second of the minute (0, ..., 59)
+- `{ampm}`: am or pm, depending on the time of day
+- `{version_ha}`, Home Assistant version string (eg 0.91.3)
+- `{version_hassos}`: HassOS version string (eg 0.2.15)
+- `{version_super}`: , Supervisor version string (eg 1.2.19)
+- `{date}`: Locale aware date (eg 2019/01/01).
+- `{time}`: Locale aware time (eg 02:03:04 am)
+- `{datetime}`: Locale-aware datetime string
+- `{isotime}`: Date and time in ISO format
+- `{hostname}`: The Home Assistant machine's hostname
 
 ### Will this ever upload to Dropbox/OnDrive/FTP/SMB/MyFavoriteProtocol?
-Most likely no.  I started this project to solve a specific problem I had, storing snapshot in a redundant cloud provider without having to write a bunch of buggy logic and automations.  It might seem like a small change to make this work with another cloud provider, but trust me.  I wrote this version of it, and its not a simple change.  I don't have the time to do.
+
+Most likely no. I started this project to solve a specific problem I had, storing snapshot in a redundant cloud provider without having to write a bunch of buggy logic and automations. It might seem like a small change to make this work with another cloud provider, but trust me. I wrote this version of it, and its not a simple change. I don't have the time to do.
 
 ### But Google reads my emails!
-Maybe.  You can encrypt your snapshots by giving a password in the add-on's options.
+
+Maybe. You can encrypt your snapshots by giving a password in the add-on's options.
 
 ### Does this store any personal information?
-On a matter of principle, I only keep track of and store information necessary for the add-on to function.  To the best of my knowledge the scope of this is:
-* You can opt-in to sending error reports from the add-on sent to a database maintained by me.  This includes the full text of the error's stack trace, the error message, and the version of the add-on you're running.  This helps notice problems with new releases but leaving it off (the default unless you turn it on) doesn't affect the functionality of the add-on in any way.
-* Once authenticated with Google, your Google credentials are only stored locally on your Home Assistant instance.  This isn't your actual username and password, only an opaque token returned from Google used to verify that you previously gave the Add-on permission to access your Google Drive.  Your password is never seen by me or the add-on.  You can read mroe abotu how authentication with Google is accomplished [here](https://github.com/sabeechen/hassio-google-drive-backup/blob/master/hassio-google-drive-backup/AUTHENTICATION.md).
-* The add-on has access to the files in Google Drive it created, which is the 'Home Assistant Snapshots' folder and any snapshots it uploads.  See the https://www.googleapis.com/auth/drive.file scope in the [Drive REST API v3 Documentation](https://developers.google.com/drive/api/v3/about-auth) for details, this is the only scope the add-on requests for your account.
-* Google stores a history of information about the number of requests, number of errors, and latency of requests made by this Add-on and makes a graph of that visible to me.  This is needed because Google only gives me a certain quota for requests shared between all users of the add-on, so I need to be aware if someone is abusing it.
-* The Add-on is distributed as a Docker container hosted on Docker Hub, which his how almost all add-ons work.  Docker keeps track of how many people have requested an image and makes that information publicly visible.
 
-This invariably means that I have a very limited ability to see how many people are using the add-on or if it is functioning well.  If you do like it, feel free to shoot me an email at [stephen@beechens.com](mailto:stephen@beechens.com) or star this repo on GitHub, it really helps keep me motivated.  If you run into problems or think a new feature would be nice, file an issue on GitHub.
+On a matter of principle, I only keep track of and store information necessary for the add-on to function. To the best of my knowledge the scope of this is:
+
+- You can opt-in to sending error reports from the add-on sent to a database maintained by me. This includes the full text of the error's stack trace, the error message, and the version of the add-on you're running. This helps notice problems with new releases but leaving it off (the default unless you turn it on) doesn't affect the functionality of the add-on in any way.
+- Once authenticated with Google, your Google credentials are only stored locally on your Home Assistant instance. This isn't your actual username and password, only an opaque token returned from Google used to verify that you previously gave the Add-on permission to access your Google Drive. Your password is never seen by me or the add-on. You can read more about how authentication with Google is accomplished [here](https://github.com/sabeechen/hassio-google-drive-backup/blob/master/hassio-google-drive-backup/AUTHENTICATION.md).
+- The add-on has access to the files in Google Drive it created, which is the 'Home Assistant Snapshots' folder and any snapshots it uploads. See the https://www.googleapis.com/auth/drive.file scope in the [Drive REST API v3 Documentation](https://developers.google.com/drive/api/v3/about-auth) for details, this is the only scope the add-on requests for your account.
+- Google stores a history of information about the number of requests, number of errors, and latency of requests made by this Add-on and makes a graph of that visible to me. This is needed because Google only gives me a certain quota for requests shared between all users of the add-on, so I need to be aware if someone is abusing it.
+- The Add-on is distributed as a Docker container hosted on Docker Hub, which his how almost all add-ons work. Docker keeps track of how many people have requested an image and makes that information publicly visible.
+
+This invariably means that I have a very limited ability to see how many people are using the add-on or if it is functioning well. If you do like it, feel free to shoot me an email at [stephen@beechens.com](mailto:stephen@beechens.com) or star this repo on GitHub, it really helps keep me motivated. If you run into problems or think a new feature would be nice, file an issue on GitHub.
 
 ### Can I use my own Google API information to authenticate instead of yours?
-On the first "Getting Started" page of the add-on underneath the "Authenticate with Google Drive" button is a link that lets you enter your own `Client Id` and `Client Sercet` to authenticate with Google Drive.  You can get back to that page by going to "Actions" -> "Reauthorize Google Drive" from the add-on's web UI if you've already connected it previously.   Instructions are also provided for those who are unfamiliar with the process, its tedious to complete but ensures the add-on's communication is only between you and Google Drive.
+
+On the first "Getting Started" page of the add-on underneath the "Authenticate with Google Drive" button is a link that lets you enter your own `Client Id` and `Client Sercet` to authenticate with Google Drive. You can get back to that page by going to "Actions" -> "Reauthorize Google Drive" from the add-on's web UI if you've already connected it previously. Instructions are also provided for those who are unfamiliar with the process, its tedious to complete but ensures the add-on's communication is only between you and Google Drive.
 
 ### Can I permanently save a snapshot so it doesn't get cleaned up?
-Select "Never Delete" from menu next to a snapshot in the add-on's Web UI.  You can choose to keep it from being deleted in Home Assistant or Google Drive.  When you do this, the snapshots will no lnger count against the maximum number of snapshots allowed in Google Drive or Home Assistant.
-Alternatively, you can move a snapshot in Google Drive out of the snapshot folder.  the add-on will ignore any files that aren't in the snapshot folder.  Just don't move them back in accidentally since they'll get "cleaned up" like any old snapshot after a while :)
+
+Select "Never Delete" from menu next to a snapshot in the add-on's Web UI. You can choose to keep it from being deleted in Home Assistant or Google Drive. When you do this, the snapshots will no longer count against the maximum number of snapshots allowed in Google Drive or Home Assistant.
+Alternatively, you can move a snapshot in Google Drive out of the snapshot folder. the add-on will ignore any files that aren't in the snapshot folder. Just don't move them back in accidentally since they'll get "cleaned up" like any old snapshot after a while :)
 
 ### What do I do if I've found an error?
-If the add-on runs into trouble and can't back up, you should see a big red box with the text of the error on the status webpage.  This should include a link to pre-populate a new issue in github, which I'd encourage you to do.  Additioanlly you can set the add-on config option `"verbose": true` to get information from the add-on's logs to help me with debugging.
 
-### Will this fill up my Google Drive?  Why are my snapshots so big?
-You'll need to take care to ensure you don't configure this to blow up your Google Drive.  You might want to consider:
-*   If your snapshots are HUGE, its probably because Home Assistant by default keeps a long sensor history.  Consider setting `purge_keep_days: N` in your [recorder confiuration](https://www.home-assistant.io/components/recorder/) to trim it down to something more manageable, like 1 day of history.
-*   Some other of the add-ons are designed to manage large amounts of media.  For example, add-ons like the Plex Media Server are designed to store media in the /share folder, and Mobile Upload folders default to a sub-folder in the addons folder.  If you migrate all of your media to the Home Assistant folder structure and you don't exclude it from the backup, you _could easily chew up your entire Google Drive space in a single snapshot_.
-*   If you use the Google Drive Desktop sync client, you'll porbably want to tell it not to sync this folder (its available in the options).
+If the add-on runs into trouble and can't back up, you should see a big red box with the text of the error on the status webpage. This should include a link to pre-populate a new issue in github, which I'd encourage you to do. Additionally you can set the add-on config option `"verbose": true` to get information from the add-on's logs to help me with debugging.
+
+### Will this fill up my Google Drive? Why are my snapshots so big?
+
+You'll need to take care to ensure you don't configure this to blow up your Google Drive. You might want to consider:
+
+- If your snapshots are HUGE, its probably because Home Assistant by default keeps a long sensor history. Consider setting `purge_keep_days: N` in your [recorder configuration](https://www.home-assistant.io/components/recorder/) to trim it down to something more manageable, like 1 day of history.
+- Some other of the add-ons are designed to manage large amounts of media. For example, add-ons like the Plex Media Server are designed to store media in the /share folder, and Mobile Upload folders default to a sub-folder in the addons folder. If you migrate all of your media to the Home Assistant folder structure and you don't exclude it from the backup, you _could easily chew up your entire Google Drive space in a single snapshot_.
+- If you use the Google Drive Desktop sync client, you'll probably want to tell it not to sync this folder (its available in the options).
 
 ### I want my snapshots to sync to my Desktop computer too
+
 Thats not a question but you can use [Google Drive Backup & Sync]([https://www.google.com/drive/download/) to download anything in your Google Drive to your desktop/laptop automatically.
 
 ### I configured this to only keep 4 snapshots in Drive and Home Assistant, but sometimes I can see there are 5?
-The add-on will only delete an old snapshot if a new one exists to replace it, so it will create a 5th one before deleting the first.  This is a reliability/disk usage compromise that favors reliability, because otherwise it would have to delete an old snapshot (leaving only 3) before it could guarantee the 4th one exists.
+
+The add-on will only delete an old snapshot if a new one exists to replace it, so it will create a 5th one before deleting the first. This is a reliability/disk usage compromise that favors reliability, because otherwise it would have to delete an old snapshot (leaving only 3) before it could guarantee the 4th one exists.
 
 ### Can I exclude specific sub-folders from my snapshot?
-The addon uses the supervisor to create snapshots, and the supervisor only permits you to include or exclude the 4 main folders (home assistant configuration, share, SSL, and local addons).  Excluding specific subfolders, or only including specific subfolders from a snapshot isn't possible today.
+
+The addon uses the supervisor to create snapshots, and the supervisor only permits you to include or exclude the 4 main folders (home assistant configuration, share, SSL, and local addons). Excluding specific subfolders, or only including specific subfolders from a snapshot isn't possible today.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you can still get to the addon's web-UI then can select "Actions" -> "Upload"
 - On your fresh install of Home Assistant:
   - [Install the add-on.](#installation) Once linked with Google Drive, you should see the snapshots you created previously show up. You should see a warning pop up about finding an "Existing snapshot folder" which is expected, you can just ignore it for now.
   - Click "Actions" -> "Upload" on the snapshot you want to use which will upload the snapshot to Home Assistant directly from Google Drive. Wait for the upload to finish.
-  - Click "Actions" -> "Restore" to be taken to the Home Assistant restore page, or just navigate there through the Home Assistant interface ("Home Assistant" -> "Snapshots").
+  - Click "Actions" -> "Restore" to be taken to the Home Assistant restore page, or just navigate there through the Home Assistant interface ("Supervisor" -> "Snapshots").
   - You'll see the snapshot you uploaded. Click on it and select "Wipe & Restore". Wait a while for it to complete (maybe a long while). Congrats! you're back up and running.
 
 Note: You can also just copy a snapshots manually from Google Drive to your /backup folder using something like the Sambda addon. I've found the steps above to be a little easier, since it works for any operating system, network setup, etc.

--- a/hassio-google-drive-backup/DOCS.md
+++ b/hassio-google-drive-backup/DOCS.md
@@ -1,0 +1,172 @@
+# Home Assistant Add-on: Google Assistant SDK
+
+## Installation
+
+To install the add-on, first follow the installation steps from the [README on GitHub](https://github.com/sabeechen/hassio-google-drive-backup#installation).
+
+## Configuration
+
+_Note_: The configuration can be changed easily by starting the add-on and clicking `Settings` in the web UI.
+The UI explains what each setting is and you don't need to modify anything before clicking `Start`.
+If you would still prefer to modify the settings in yaml, the options are detailed below.
+
+Add-on configuration example (do not use directly):
+
+```yaml
+# Keep 10 snapshots in Home Assistant
+max_snapshots_in_hassio: 10
+# Keep 10 snapshots in Google Drive
+max_snapshots_in_google_drive: 10
+# Take a snapshot every 3 days
+days_between_snapshots: 3
+# Create snapshots at 1:30pm
+snapshot_time_of_day: "13:30"
+# Specify the snapshot folder
+specify_snapshot_folder: true
+# Use a dark and red theme
+background_color: "#242424"
+accent_color: "#7D0034"
+# Notify after 12 hours of staleness
+snapshot_stale_minutes: 500
+# Use a password for snapshot archives
+snapshot_password: "super_secret"
+# Create snapshot names like 'Full Snapshot HA 0.92.0'
+snapshot_name: "{type} Snapshot {version_ha}"
+# Keep a snapshot once every day 3 days and once a week for 4 weeks
+generational_days: 3
+generational_weeks: 4
+# Create partial snapshots with no folders and no configurator add-on
+exclude_folders: "homeassistant,ssl,share,addons/local"
+exclude_addons: "core_configurator"
+# Turn off notifications and staleness sensor
+enable_snapshot_stale_sensor: false
+enable_snapshot_state_sensor: false
+notify_for_stale_snapshots: false
+# Enable server directly on port
+expose_extra_server: true
+# Use SSL for the extra server
+use_ssl: true
+# Don't require login
+require_login: false
+# Use certs you keep in a weird place
+certfile: "/ssl/weird/path/cert.pem"
+keyfile: "/ssl/weird/path/key.pem"
+# Turn on verbose logging
+verbose: true
+# Allow sending error reports
+send_error_reports: true
+```
+
+### Option: `max_snapshots_in_hassio` (default: 4)
+
+The number of snapshots the add-on will allow Home Assistant to store locally before old ones are deleted.
+
+### Option: `max_snapshots_in_google_drive` (default: 4)
+
+The number of snapshots the add-on will keep in Google Drive before old ones are deleted. Google Drive gives you 15GB of free storage (at the time of writing) so plan accordingly if you know how big your snapshots are.
+
+### Option: `days_between_snapshots` (default: 3)
+
+How often a new snapshot should be scheduled, eg `1` for daily and `7` for weekly.
+
+### Option: `snapshot_time_of_day`
+
+The time of day (local time) that new snapshots should be created in 24 hour "HH:MM" format. When not specified (the default), snapshots are created at the same time of day of the most recent snapshot.
+
+### Option: `specify_snapshot_folder` (default: False)
+
+When true, you must select the folder in Google Drive where snapshots are stored. Once you turn this on, restart the add-on and visit the web-ui to be prompted to select the snapshot folder.
+
+### Option: `background_color` and `accent_color`
+
+The background and accent colors for the web UI. You can use this to make the UI fit in with whatever color scheme you use in Home Assistant. When unset, the interface matches Home Assistant's default blue/white style.
+
+### Option: `snapshot_stale_minutes` (default: 180)
+
+How long to wait after a snapshot should have been created to consider snapshots stale and in need of attention. Setting this too low can cause you to be notified of transient errors, ie the internet, Google Drive, or Home Assistant being offline briefly.
+
+### Option: `snapshot_password`
+
+When set, snapshots are created with a password. You can use a value from your secrets.yaml by prefixing the password with "!secret". You'll need to remember this password when restoring snapshots.
+
+> Example: Use a password for snapshot archives
+>
+> ```json
+> "snapshot_password": "super_secret"
+> ```
+>
+> Example: Use a password from secrets.yaml
+>
+> ```json
+> "snapshot_password": "!secret snapshot_password"
+> ```
+
+### Option: `snapshot_name` (default: "{type} Snapshot {year}-{month}-{day} {hr24}:{min}:{sec}")
+
+Sets the name for new snapshots. Variable parameters of the form `{variable_name}` can be used to modify the name to your liking. A list of available variables are given [here](https://github.com/sabeechen/hassio-google-drive-backup#can-i-give-snapshots-a-different-name).
+
+### Option: `generational_*`
+
+When set, older snapshots will be kept longer using a [generational backup scheme](https://en.wikipedia.org/wiki/Backup_rotation_scheme). See the [question here](https://github.com/sabeechen/hassio-google-drive-backup#can-i-keep-older-backups-for-longer) for configuration options.
+
+### Option: `exclude_folders`
+
+When set, excludes the comma separated list of folders by creating a partial snapshot.
+
+### Option: `exclude_addons`
+
+When set, excludes the comma separated list of addons by creating a partial snapshot.
+
+_Note_: Folders and add-ons must be identified by their "slug" name. It is recommended to use the `Settings` dialog within the add-on web UI to configure partial snapshots since these names are esoteric and hard to find.
+
+### Option: `enable_snapshot_stale_sensor` (default: True)
+
+When false, the add-on will not publish the [binary_sensor.snapshots](https://github.com/sabeechen/hassio-google-drive-backup#how-will-i-know-this-will-be-there-when-i-need-it) stale sensor.
+
+### Option: `enable_snapshot_state_sensor` (default: True)
+
+When false, the add-on will not publish the [sensor.snapshot_state](https://github.com/sabeechen/hassio-google-drive-backup#how-will-i-know-this-will-be-there-when-i-need-it) sensor.
+
+### Option: `notify_for_stale_snapshots` (default: True)
+
+When false, the add-on will send a [persistent notification](https://github.com/sabeechen/hassio-google-drive-backup#how-will-i-know-this-will-be-there-when-i-need-it) in Home Assistant when snapshots are stale.
+
+---
+
+### UI Server Options
+
+The UI is available through Home Assistant [ingress](https://www.home-assistant.io/blog/2019/04/15/hassio-ingress/).
+
+It can also be exposed through a webserver on port `1627`, which you can map to an externally visible port from the add-on `Network` panel. You can configure a few more options to add SSL or require your Home Assistant username/password.
+
+#### Option: `expose_extra_server` (default: False)
+
+Expose the webserver on port `1627`. This is optional, as the add-on is already available with Home Assistant ingress.
+
+#### Option: `require_login` (default: False)
+
+When true, requires your home assistant username and password to access the Web UI.
+
+#### Option: `use_ssl` (default: False)
+
+When true, requires your home assistant username and password to access the Web UI.
+
+#### Option: `certfile` (default: `/ssl/certfile.pem`)
+
+Required when `use_ssl: True`. The path to your ssl keyfile
+
+#### Option: `keyfile` (default: `/ssl/keyfile.pem`)
+
+Required when `use_ssl: True`. The path to your ssl certfile.
+
+#### Option: `verbose` (default: False)
+
+If true, enable additional debug logging. Useful if you start seeing errors and need to file a bug with me.
+
+#### Option: `send_error_reports` (default: False)
+
+When true, the text of unexpected errors will be sent to database maintained by the developer. This helps identify problems with new releases and provide better context messages when errors come up.
+
+## FAQ
+
+Read the [FAQ on GitHub](https://github.com/sabeechen/hassio-google-drive-backup#faq).

--- a/hassio-google-drive-backup/README.md
+++ b/hassio-google-drive-backup/README.md
@@ -1,12 +1,23 @@
-A complete and easy way to back up Home Assistant to Google Drive.
-* Create snapshots on a configurable schedule.
-* Clean up old snapshots in Home Assistant and Google Drive.
-* Recover quickly from disaster by uploading your snapshots directly from Google Drive.
-* Notifies you when something goes wrong with your snapshots.
-* Super easy installation and configuration.
-* Simple, understandable interface with clear language.
-* Privacy-centric design philosophy.
-* Comprehensive documentation.
-* *Most certainly* doesn't mine bitcoin on your home automation server.  Definitely no.
+# Home Assistant Add-on: Google Drive Backup
 
-See the [readme on GitHub](https://github.com/sabeechen/hassio-google-drive-backup) for all the details, or just install the add-on and open the Web UI.  The Web-UI explains everything you have to do.
+A complete and easy way to back up your Home Assistant snapshots to Google Drive.
+
+## About
+
+Quickly set up a backup strategy without much fuss. It doesn't require much familiarity with Home Assistant, its architecture, or Google Drive. Detailed install instructions are provided below but you can just add the repo, click install and open the Web UI. It will tell you what to do and only takes a few simple clicks.
+
+### Features
+
+- Creates snapshots on a configurable schedule.
+- Uploads snapshot to Drive, even the ones it didn't create.
+- Clean up old snapshots in Home Assistant and Google Drive, so you don't run out of space.
+- Restore from a fresh install or recover quickly from disaster by uploading your snapshots directly from Google Drive.
+- Integrates with Home Assistant Notifications, and provides sensors you can trigger off of.
+- Notifies you when something goes wrong with your snapshots.
+- Super easy installation and configuration.
+- Privacy-centric design philosophy.
+- Comprehensive documentation.
+- _Most certainly_ doesn't mine bitcoin on your home automation server. Definitely no.
+
+See the [README on GitHub](https://github.com/sabeechen/hassio-google-drive-backup) for all the details, or just install the add-on and open the Web UI.
+The Web-UI explains everything you have to do.

--- a/hassio-google-drive-backup/backup/util/error_analyzer.py
+++ b/hassio-google-drive-backup/backup/util/error_analyzer.py
@@ -4,7 +4,7 @@ from firebase_admin import credentials
 from firebase_admin import firestore
 from pathlib import Path
 
-
+KNWON_ERRORS = ['existing_backup_folder', 'google_dns', 'cancelled', 'google_timeout', 'low_space', 'multiple_deletes']
 async def main():
     cred = credentials.Certificate(str(Path.home().joinpath("Documents/secrets/server-firestore-creds.json")))
     firebase_admin.initialize_app(cred)
@@ -25,9 +25,7 @@ async def main():
             print("Done")
         if command == "":
             # Do regular analysis
-            print("Inspecting the last 24 hours of records...")
-            for item in reports.stream():
-                pass
+            await stats(db, reports)
         if command.startswith("get "):
             query = reports.where("report.client", "==", command[4:])
             for report in query.get():
@@ -39,6 +37,59 @@ async def main():
     # stream = reports.stream()
     for report in query.get():
         print(report.to_dict())
+
+
+async def stats(db, reports):
+    print("Inspecting the last 24 hours of records...")
+    cursor = None
+    batch_size = 50
+    summary = {}
+    resolved = {}
+    total = 0
+    while True:
+        count = 0
+        if cursor is None:
+            stream = reports.limit(batch_size).stream()
+        else:
+            stream = reports.limit(batch_size).start_after(cursor).stream()
+        for report in stream:
+            cursor = report
+            data = report.to_dict()
+            count += 1
+            total += 1
+            if 'report' not in data:
+                continue
+            if 'error' not in data['report']:
+                resolved[data['client']] = data['report']['duration']
+                continue
+            if data['report']['error'] in summary:
+                summary[data['report']['error']].append(data)
+            else:
+                summary[data['report']['error']] = [data]
+        print("Processed " + str(count) + " records")
+        if count == 0:
+            break
+    for error in summary.keys():
+        print("")
+        distinct = set()
+        unresolved = {}
+        versions = set()
+        for report in summary[error]:
+            distinct.add(report['client'])
+            if report['client'] not in resolved:
+                unresolved[report['client']] = report
+            versions.add(report['version'])
+        print("Unresolved: " + str(len(unresolved)))
+        print("Count: " + str(len(summary[error])))
+        print("Distinct: " + str(len(distinct)))
+        print("Versions: " + str(versions))
+        print("Error: " + error)
+        if len(unresolved) > 0:
+            print("Unresolved: ")
+            for unres in unresolved.values():
+                print("  " + unres['report']['arch'] + " " + unres['client'])
+    print("Total records: " + str(total))
+
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/hassio-google-drive-backup/tests/test_model.py
+++ b/hassio-google-drive-backup/tests/test_model.py
@@ -142,6 +142,22 @@ def test_next_time_of_day(estimator):
         1985, 12, 6, 8, 0, tzinfo=test_tz)) == datetime(1985, 12, 7, 8, 0, tzinfo=test_tz)
 
 
+def test_next_time_of_day_drift(estimator):
+    time: FakeTime = FakeTime()
+    info = GlobalInfo(time)
+    now: datetime = datetime(1985, 12, 6, 1, 0, 0).astimezone(timezone.utc)
+
+    config: Config = Config().override(Setting.DAYS_BETWEEN_SNAPSHOTS, 1).override(
+        Setting.SNAPSHOT_TIME_OF_DAY, '08:00')
+    model: Model = Model(config, time, default_source,
+                         default_source, info, estimator)
+
+    assert model._nextSnapshot(
+        now=now, last_snapshot=None) == now - timedelta(minutes=1)
+    assert model._nextSnapshot(
+        now=now, last_snapshot=now - timedelta(days=1) + timedelta(minutes=1)) == now
+
+
 def test_next_time_of_day_dest_disabled(model, time, source, dest):
     dest.setEnabled(True)
     assert model._nextSnapshot(


### PR DESCRIPTION
Hi again :)

This PR moves things around a little, in order to be more up to date with new Home Assistant add-ons, and also to be easier to read.

### Live preview

- Repo readme: https://github.com/ericmatte/hassio-google-drive-backup/blob/hassio-unify-documentation/README.md
- Add-on info tab: https://github.com/ericmatte/hassio-google-drive-backup/blob/hassio-unify-documentation/hassio-google-drive-backup/README.md
- Add-on documentation tab (DOCS.md): https://github.com/ericmatte/hassio-google-drive-backup/blob/hassio-unify-documentation/hassio-google-drive-backup/DOCS.md

### What changed ?

- Fix some typos and formatting
- Use the new `DOCS.md` for Home Assistant add-on (more info here: https://developers.home-assistant.io/docs/add-ons/presentation/#adding-documentation)
- Examples now uses yaml instead of json, since Home Assistant now use yaml for add-ons
- Updated some section of the readme (se comments in file)

The `DOCS.md` let you extract all the configuration options from the main readme, allowing an easier read for newcomers.
It also adds a new `Documentation` tab after installing the add-on, which contains all the markdown from that file.

Example from the Google Assistant SDK add-on:

![2020-08-29 at 19 13](https://user-images.githubusercontent.com/9013072/91647701-b5a1e200-ea2b-11ea-97c8-8879e7d01aa1.png)
