### PR TITLE
Fix backups don't start at scheduled time

### DIFF
--- a/hassio-google-drive-backup/backup/model/model.py
+++ b/hassio-google-drive-backup/backup/model/model.py
@@ -131,10 +131,7 @@ class Model():
             # return the next snapshot after the delta
             next = self.time.toUtc(
                 time_that_day_local + timedelta(days=self.config.get(Setting.DAYS_BETWEEN_SNAPSHOTS)))
-        if next < now:
-            return now
-        else:
-            return next
+        return next
 
     def nextSnapshot(self, now: datetime):
         latest = max(self.snapshots.values(),

--- a/hassio-google-drive-backup/tests/test_model.py
+++ b/hassio-google-drive-backup/tests/test_model.py
@@ -133,7 +133,8 @@ def test_next_time_of_day(estimator):
     assert model._nextSnapshot(
         now=now, last_snapshot=None) == now - timedelta(minutes=1)
     assert model._nextSnapshot(
-        now=now, last_snapshot=now - timedelta(days=1)) == now
+        now=now, last_snapshot=now - timedelta(days=1)) == datetime(
+        1985, 12, 5, 8, 0, tzinfo=test_tz)
     assert model._nextSnapshot(now=now, last_snapshot=now) == datetime(
         1985, 12, 6, 8, 0, tzinfo=test_tz)
     assert model._nextSnapshot(now=now, last_snapshot=datetime(
@@ -155,7 +156,7 @@ def test_next_time_of_day_drift(estimator):
     assert model._nextSnapshot(
         now=now, last_snapshot=None) == now - timedelta(minutes=1)
     assert model._nextSnapshot(
-        now=now, last_snapshot=now - timedelta(days=1) + timedelta(minutes=1)) == now
+        now=now, last_snapshot=now - timedelta(days=1) + timedelta(minutes=1)) == datetime(1985, 12, 5, 8, 0, tzinfo=test_tz)
 
 
 def test_next_time_of_day_dest_disabled(model, time, source, dest):


### PR DESCRIPTION
When coordinator.check() runs after the schedule backup time, model._nextSnapshot() could inadvertantly report that the next snapshot attempt is slightly after the start of the current sync check due to a timing issue between when coordinator.check() starts and when model._nextSnapshot() is called. This would happen on each sync check until the MAX_SYNC_INTERVAL.

This change will cause model._nextSnapshot() to return the next scheduled snapshot time even if the schedule time has already passed, eliminating the timing issue between the coordinator.check() and model._nextSnapshot() calls.

Fixes #166 