### PR TITLE
Add CI addon config lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  build:
+    name: Add-on configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v2
+      - name: 🚀 Run Home Assistant Add-on Lint on hassio-google-drive-backup
+        uses: frenck/action-addon-linter@v2
+        with:
+          path: "./hassio-google-drive-backup"

--- a/hassio-google-drive-backup/config.json
+++ b/hassio-google-drive-backup/config.json
@@ -4,18 +4,14 @@
   "slug": "hassio_google_drive_backup",
   "description": "Automatically back up Home Assistant snapshots to Google Drive",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
-  "startup": "application",
-  "boot": "auto",
   "url": "https://github.com/sabeechen/hassio-google-drive-backup",
   "homeassistant_api": true,
   "hassio_api": true,
   "hassio_role": "manager",
   "auth_api": true,
-  "webui": "[PROTO:use_ssl]://[HOST]:[PORT:1627]/",
   "ingress": true,
   "panel_icon": "mdi:cloud",
   "panel_title": "Snapshots",
-  "panel_admin": true,
   "map": ["ssl", "backup:rw", "config"],
   "options": {
     "max_snapshots_in_hassio": 4,
@@ -116,5 +112,8 @@
   "ports": {
     "1627/tcp": 1627
   },
+  "ports_description": {
+    "1627/tcp": "Web UI to manage Google connection"
+  },  
   "image": "sabeechen/hassio-google-drive-backup-{arch}"
 }


### PR DESCRIPTION
Frenck wrote a little Github action, that lints the config file of addons:
https://github.com/frenck/action-addon-linter

This PR implements that linter via Github CI and also removes parameter, that had the default value (according to the linter) and could therefore be removed.
Additionally a description for the port usage is added.

The result for the first run of the CI can be seen here:
https://github.com/TheZoker/hassio-google-drive-backup/actions/runs/549027011