### PR TITLE
About modal tweaks

### DIFF
--- a/hassio-google-drive-backup/backup/static/css/static.css
+++ b/hassio-google-drive-backup/backup/static/css/static.css
@@ -258,12 +258,6 @@ nav .brand-logo img {
 .bmc-outline {
   fill: var(--accent-dark)
 }
-
-#contributors-simple a {
-  margin-right: 8px;
-  margin-bottom: 8px;
-}
-
 .btn-floating {
   background-color: var(--accent-color);
   color: var(--accent-text-color);
@@ -273,7 +267,17 @@ nav .brand-logo img {
   background-color: var(--accent-color);
 }
 
-#contributors-simple a img {
+#contributors-simple a {
+  margin-right: 8px;
+  margin-bottom: 8px;
+}
+
+#contributors-extra .contributor-img-wrapper a {
+  display: flex;
+  margin-right: 8px;
+}
+
+#contributors a img {
   width: 32px;
   height: 32px;
   border-radius: 9999px;
@@ -287,21 +291,10 @@ nav .brand-logo img {
   font-weight: 500;
 }
 
-.contributor-name {
-  vertical-align: middle;
-}
-
-#contributors-extra a {
-  margin-right: 8px;
-  margin-bottom: 8px;
+.contributor-extra {
   display: flex;
-  align-content: center;
-}
-
-#contributors-extra a img {
-  width: 32px;
-  height: 32px;
-  border-radius: 9999px;
+  align-items: center;
+  margin-bottom: 16px;
 }
 
 .truncate-two-lines {

--- a/hassio-google-drive-backup/backup/static/js/about.js
+++ b/hassio-google-drive-backup/backup/static/js/about.js
@@ -75,6 +75,8 @@ async function loadContributor(contributor) {
 }
 
 async function fetchContributors() {
+  if (contributorsLoaded) return;
+  
   const data = await fetch(CONTRIBUTORS_API_URL);
   showElement("contributors-loading");
   hideElement("contributors-count");

--- a/hassio-google-drive-backup/backup/static/layouts/partials/footer.jinja2
+++ b/hassio-google-drive-backup/backup/static/layouts/partials/footer.jinja2
@@ -34,7 +34,7 @@
       </svg>
       <span>Buy me a coffee</span>
     </a>
-    <a onclick="openAbout()" href="#" style="margin-left: 5px"> + other ways</a>
+    <a href="#!" class="modal-trigger" data-target="about_modal" style="margin-left: 5px"> + other ways</a>
   </div>
 </footer>
     

--- a/hassio-google-drive-backup/backup/static/layouts/partials/modals/about.jinja2
+++ b/hassio-google-drive-backup/backup/static/layouts/partials/modals/about.jinja2
@@ -8,7 +8,7 @@
       <a href="https://github.com/sabeechen" target="_blank" rel="noreferrer">Github</a>
       or just gimme money at:
       <br>
-      <a class="bmc-button" target="_blank" rel="noreferrer" href="https://www.buymeacoffee.com/sabeechen" style="margin: 15px;">
+      <a class="bmc-button" target="_blank" rel="noreferrer" href="https://www.buymeacoffee.com/sabeechen" style="margin: 15px; margin-left: 0;">
         <img src="{{ bmc_logo_path }}" alt="Support me"><span>Buy me a coffee</span>
       </a>
       <a href="https://www.paypal.com/paypalme/stephenbeechen?locale.x=en_US" target="_blank" rel="noreferrer" style="margin: 15px;">
@@ -21,18 +21,20 @@
     </p>
 
     <h5>
-      Contributors <span><span id="contributors-count"></span></span>
+      Contributors <span id="contributors-count" class="default-hidden"></span>
     </h5>
-    <div id="contributors-loading" class="progress" style="width: 30%;">
+    <div id="contributors-loading" class="progress" style="width: 30%; margin-top: 22px; margin-bottom: 22px;">
       <div class="indeterminate"></div>
     </div>
-    <p id="contributors-extra" style="margin-bottom: 6px;">
-    </p>
-    <p id="contributors-simple" style="margin-bottom: 6px;">
-    </p>
-    <a href="https://github.com/sabeechen/hassio-google-drive-backup/graphs/contributors">
-      + <span id="contributors-more-link-count"></span> more
-    </a>
+    <div id="contributors" class="default-hidden">
+      <p id="contributors-extra" style="margin-bottom: 24px;">
+      </p>
+      <p id="contributors-simple" style="margin-bottom: 6px;">
+      </p>
+      <a href="https://github.com/sabeechen/hassio-google-drive-backup/graphs/contributors" target="_blank">
+        + <span id="contributors-more-link-count"></span> more
+      </a>
+    </div>
 
     <h5>Connect</h5>
     <ul class="browser-default">

--- a/hassio-google-drive-backup/backup/static/layouts/partials/navbar.jinja2
+++ b/hassio-google-drive-backup/backup/static/layouts/partials/navbar.jinja2
@@ -64,7 +64,7 @@
     <li><a href="reauthenticate"><i class="material-icons">vpn_key</i>Reauthorize Google Drive</a></li>
   {% endif %}
   <li><a onclick="bugReport()" style="cursor: pointer"><i class="material-icons">bug_report</i>Report a bug</a></li>
-  <li><a onclick="openAbout()" href="#!"><i class="material-icons">info</i>About</a></li>
+  <li><a href="#!" class="modal-trigger" data-target="about_modal"><i class="material-icons">info</i>About</a></li>
 </ul>
 {% endmacro %}
 
@@ -120,7 +120,7 @@
   {% endif %}
   <li><a href="#!" data-target="help_modal" class="modal-trigger"><i class="material-icons">help</i>Get Help</a></li>
   <li><a onclick="bugReport()" style="cursor: pointer"><i class="material-icons">bug_report</i>Report a bug</a></li>
-  <li><a onclick="openAbout()" href="#!"><i class="material-icons">info</i>About</a></li>
+  <li><a href="#!" class="modal-trigger" data-target="about_modal"><i class="material-icons">info</i>About</a></li>
 </ul>
 
 {% if coordEnabled %}

--- a/hassio-google-drive-backup/backup/static/working.jinja2
+++ b/hassio-google-drive-backup/backup/static/working.jinja2
@@ -182,7 +182,7 @@
           <div class="row">
             <div class='col s1'></div>
             <div class='col s2 valign-wrapper center'>
-              <i class='red-text text-darken-4 material-icons' style="font-size: 90px">block</i>
+              <i class='material-icons' style="font-size: 90px">info_outline</i>
             </div>
             <div class='col s7 center valign-wrapper' style="margin-top: 10px;">
               <p>You don't have any snapshots in Google Drive or Home Assistant. Use the "Actions" menu up top


### PR DESCRIPTION
Hey @sabeechen !

First of all, thanks for the kind words about my work that you put in the about modal 😄 🧙  This is appreciated.
I just wanted to add a little more tweaks/cleanup to the modal, so here it is!

Also about the rest for the next release, I've installed the staging version on my HA and tested some basic functionalities, and from what I've tested, everything seems good 👍 

### What changed?

<details open>
<summary><b>Tweaks for the about modal</b></summary>
<br>

![image](https://user-images.githubusercontent.com/9013072/111731015-fb4bbe00-8848-11eb-8065-a10574ddf5ff.png)

- I changed the layout/alignment of the items a little.
- Now there is a link that show all the extra-contributors contributions on the project
  - Example with me: [**19 contributions**](https://github.com/sabeechen/hassio-google-drive-backup/commits?author=ericmatte)
- I've also tweak the loading to wait for all avatar images to be loaded before showing the section. Without this, it can be a little glitchy on slow network (see the after/before below).

#### After

_In these examples, I've simulated a slow network. It is quicker normally._

https://user-images.githubusercontent.com/9013072/111730758-73fe4a80-8848-11eb-92fd-18dca9450863.mp4

#### Before


https://user-images.githubusercontent.com/9013072/111730968-dfe0b300-8848-11eb-8176-fc060647b69d.mp4



---

</details>

<details open>
<summary><b>Use info_outline icon instead of block when no snapshots</b></summary>
<br>

I just think it make more sense to have an info icon instead of error in that particular case.

#### After

![image](https://user-images.githubusercontent.com/9013072/111730157-2df4b700-8847-11eb-8c2f-78f31f20f07f.png)

#### Before

![image](https://user-images.githubusercontent.com/9013072/111730223-4e247600-8847-11eb-8b1b-c5cffd37fb58.png)

---

</details>