### PR TITLE
Remove whitespaces from the credentials string

### DIFF
--- a/hassio-google-drive-backup/backup/ui/uiserver.py
+++ b/hassio-google-drive-backup/backup/ui/uiserver.py
@@ -392,7 +392,7 @@ class UiServer(Trigger, Startable):
 
     async def token(self, request: Request) -> None:
         self._global_info.setIngoreErrorsForNow(True)
-        creds_deserialized = json.loads(str(base64.b64decode(request.query.get('creds').encode("utf-8")), 'utf-8'))
+        creds_deserialized = json.loads(str(base64.b64decode(request.query.get('creds').encode("utf-8")), 'utf-8')).replace(" ", "")
         creds = Creds.load(self._time, creds_deserialized)
         self._coord.saveCreds(creds)
 

--- a/hassio-google-drive-backup/backup/ui/uiserver.py
+++ b/hassio-google-drive-backup/backup/ui/uiserver.py
@@ -392,7 +392,7 @@ class UiServer(Trigger, Startable):
 
     async def token(self, request: Request) -> None:
         self._global_info.setIngoreErrorsForNow(True)
-        creds_deserialized = json.loads(str(base64.b64decode(request.query.get('creds').encode("utf-8")), 'utf-8')).replace(" ", "")
+        creds_deserialized = json.loads(str(base64.b64decode(request.query.get('creds').encode("utf-8").trim()), 'utf-8'))
         creds = Creds.load(self._time, creds_deserialized)
         self._coord.saveCreds(creds)
 


### PR DESCRIPTION
The box containing the credentials have some spaces before and after the code that is being copied. I had to manually remove the spaces after pasting the copied text into the authentication page on Home Assistant. I thought it would be safe to remove white spaces in this file. Let me know what you think.