### PR TITLE
Fix use_ssl description in docs

### DIFF
--- a/hassio-google-drive-backup/DOCS.md
+++ b/hassio-google-drive-backup/DOCS.md
@@ -178,7 +178,7 @@ When true, requires your home assistant username and password to access the Web 
 
 #### Option: `use_ssl` (default: False)
 
-When true, requires your home assistant username and password to access the Web UI.
+When true, the Web UI exposed by `expose_extra_server` will be served over SSL (HTTPS).
 
 #### Option: `certfile` (default: `/ssl/certfile.pem`)
 


### PR DESCRIPTION
It seems like the description for the `use_ssl` option was copied/pasted by mistake from the one regarding `require_login`.

A correct description for `use_ssl` is now provided.