### PR TITLE
A few fixes

### DIFF
--- a/hassio-google-drive-backup/backup/ui/uiserver.py
+++ b/hassio-google-drive-backup/backup/ui/uiserver.py
@@ -821,6 +821,8 @@ class UiServer(Trigger, Startable):
                 query['client_id'] = 'redacted'
             if 'client_secret' in query:
                 query['client_secret'] = 'redacted'
+            if 'creds' in query:
+                query['creds'] = 'redacted'
             url = url.with_query(query)
         except Exception as e:
             # Fall back to just returning the url if it was malformed

--- a/hassio-google-drive-backup/config.json
+++ b/hassio-google-drive-backup/config.json
@@ -97,6 +97,7 @@
     "snapshot_password": "str?",
     "maximum_upload_chunk_bytes": "float(262144,)?",
     "ha_reporting_interval_seconds": "int(1,)?",
+    "pending_backup_timeout_seconds": "float(0,)?",
 
     "upload_limit_bytes_per_second": "float(0,)?",
     "backup_check_interval_seconds": "float(0.5,)?"


### PR DESCRIPTION
Redact 'creds' url parameter when printing error urls to the log
Add `pending_backup_timeout_seconds` as a valid config option to the addon