### PR TITLE
Adjust helper text for bandwidth limit to make units clearer

### DIFF
--- a/hassio-google-drive-backup/backup/static/layouts/partials/modals/settings.jinja2
+++ b/hassio-google-drive-backup/backup/static/layouts/partials/modals/settings.jinja2
@@ -551,9 +551,9 @@
                 class="validate" />
               <label for="upload_limit_bytes_per_second">Upload Bandwidth Limit</label>
               <span class="helper-text">
-                Sets a bandwidth limit for uploads to Google Drive, useful if you find uploads saturating your network.
+                Sets a bandwidth limit in bytes for uploads to Google Drive, useful if you find uploads saturating your network.
                 The value can be provided in any binary-prefix format, e.g. '256 Kb', '10 Mb', '3000Kb', etc. The speed
-                will be interpreted as "per second" so a value of "10 MB" will limit the upload speed to 10 MB per
+                will be interpreted as "per second" so a value of "10 MB" or "10Mb" will limit the upload speed to 10 megabytes per
                 second.</span>
             </div>
           </div>


### PR DESCRIPTION
It's not very clear from current description that it only accepts bytes per second.

E.g. that "10 Kb" still means kilobytes while it's more common for it to mean kilobits, especially in network speed context.