### PR TITLE
Fix pluralisation of delta timestamps

### DIFF
--- a/hassio-google-drive-backup/backup/time.py
+++ b/hassio-google-drive-backup/backup/time.py
@@ -137,24 +137,24 @@ class Time(object):
             plural = "s" if delta.years > 1 else ""
             return "{0} year{2}{1}".format(delta.years, flavor, plural)
         if (delta.months != 0):
-            plural = "s" if delta.months > 1 else ""
             if delta.days > 15:
-                return "{0} month{2}{1}".format(delta.months + 1, flavor, plural)
+                delta.months += 1
+            plural = "s" if delta.months > 1 else ""
             return "{0} month{2}{1}".format(delta.months, flavor, plural)
         if (delta.days != 0):
-            plural = "s" if delta.days > 1 else ""
             if delta.hours >= 12:
-                return "{0} day{2}{1}".format(delta.days + 1, flavor, plural)
+                delta.days += 1
+            plural = "s" if delta.days > 1 else ""
             return "{0} day{2}{1}".format(delta.days, flavor, plural)
         if (delta.hours != 0):
-            plural = "s" if delta.hours > 1 else ""
             if delta.minutes >= 30:
-                return "{0} hour{2}{1}".format(delta.hours + 1, flavor, plural)
+                delta.hours += 1
+            plural = "s" if delta.hours > 1 else ""
             return "{0} hour{2}{1}".format(delta.hours, flavor, plural)
         if (delta.minutes != 0):
+            if delta.seconds >= 30:
+                delta.minutes += 1
             plural = "s" if delta.minutes > 1 else ""
-            if delta.minutes >= 30:
-                return "{0} minute{2}{1}".format(delta.minutes + 1, flavor, plural)
             return "{0} minute{2}{1}".format(delta.minutes, flavor, plural)
         if (delta.seconds != 0):
             plural = "s" if delta.seconds > 1 else ""

--- a/hassio-google-drive-backup/tests/test_time_delta.py
+++ b/hassio-google-drive-backup/tests/test_time_delta.py
@@ -1,0 +1,14 @@
+from backup.time import Time
+from .faketime import FakeTime
+
+
+def test_format_delta_plural() -> None:
+    assert Time().formatDelta(FakeTime().advance(days=800).now(), FakeTime().now()) == "2 years"
+    assert Time().formatDelta(FakeTime().advance(days=366).now(), FakeTime().now()) == "1 year"
+    assert Time().formatDelta(FakeTime().advance(days=50).now(), FakeTime().now()) == "2 months"
+    assert Time().formatDelta(FakeTime().advance(days=40).now(), FakeTime().now()) == "1 month"
+    assert Time().formatDelta(FakeTime().advance(days=1, hours=17).now(), FakeTime().now()) == "2 days"
+    assert Time().formatDelta(FakeTime().advance(days=1, hours=4).now(), FakeTime().now()) == "1 day"
+    assert Time().formatDelta(FakeTime().advance(hours=1, minutes=38).now(), FakeTime().now()) == "2 hours"
+    assert Time().formatDelta(FakeTime().advance(minutes=1, seconds=35).now(), FakeTime().now()) == "2 minutes"
+    assert Time().formatDelta(FakeTime().advance(seconds=35).now(), FakeTime().now()) == "35 seconds"


### PR DESCRIPTION
Pluralise timestamps if the time unit is rounded up by pluralising after rounding
Correct a bug where minutes were not rounded up if seconds were greater than 30

Fixes: #1066